### PR TITLE
fix: enhance translation tab selection and verse link spacing

### DIFF
--- a/implementation_files/IMPROVEMENT_BACKLOG_STATUS.md
+++ b/implementation_files/IMPROVEMENT_BACKLOG_STATUS.md
@@ -1,0 +1,71 @@
+# UX/UI Improvement Backlog Status
+
+Last Updated: 2025-12-23
+
+## Quick Reference
+- 🔴 Blocked/Stuck
+- 🟡 In Progress  
+- 🟢 Completed
+- ⚪ Not Started
+
+---
+
+## Critical Bugs (Fix First)
+| Status | Issue | Description | Branch |
+|--------|-------|-------------|--------|
+| 🟡 | BUG-001 | Translation tab selection not visually prominent | `fix/translation-tab-highlight` |
+| 🟡 | BUG-002 | Missing space before/after verse links in text | `fix/verse-link-spacing` |
+
+---
+
+## P0 - Critical Priority
+| Status | Issue # | Title | Branch | Notes |
+|--------|---------|-------|--------|-------|
+| ⚪ | #26 | Implement functional bottom navigation | | |
+| ⚪ | #27 | Add week selector/picker for quick navigation | | Calendar/dropdown for weeks |
+
+## P1 - High Priority  
+| Status | Issue # | Title | Branch | Notes |
+|--------|---------|-------|--------|-------|
+| ⚪ | #28 | Implement horizontal swipe navigation | | |
+| ⚪ | #29 | Establish typography scale system | | |
+| ⚪ | #30 | Add pull-to-refresh for data reload | | |
+| ⚪ | #31 | Implement dynamic type / font scaling | | |
+| ⚪ | #32 | Add empty states for missing content | | |
+| ⚪ | #33 | Establish consistent spacing system | | |
+| ⚪ | #34 | Enhance current week indicator | | |
+| ⚪ | #35 | Add section headers with visual dividers | | |
+
+## P2 - Medium Priority
+| Status | Issue # | Title | Branch | Notes |
+|--------|---------|-------|--------|-------|
+| ⚪ | #36 | Add haptic feedback | | |
+| ⚪ | #37 | Implement reduced motion support | | |
+| ⚪ | #38 | Add offline support indicators | | |
+| ⚪ | #39 | Improve verse modal gestures | | |
+| ⚪ | #40 | Add high contrast mode | | |
+| ⚪ | #41 | Implement optimistic UI | | |
+| ⚪ | #42 | Loading states for translation switching | | |
+| ⚪ | #43 | Document design tokens | | |
+| ⚪ | #44 | Add toast notifications | | |
+| ⚪ | #45 | Enhance error states | | |
+| ⚪ | #46 | Focus management audit | | |
+| ⚪ | #47 | Scroll-aware sticky header | | |
+| ⚪ | #48 | Scripture-specific typography | | |
+
+---
+
+## Completed Work Log
+
+### 2025-12-23
+- Created 24 GitHub issues (#25-#48)
+- Created labels: P0, P1, P2, ux, ui, accessibility, performance, refactor, mobile
+- Created Epic issue #25
+
+---
+
+## Blocked Issues
+| Issue | Reason | Needs |
+|-------|--------|-------|
+| (none yet) | | |
+

--- a/mfers-app/src/components/reading/VerseLink.tsx
+++ b/mfers-app/src/components/reading/VerseLink.tsx
@@ -22,16 +22,20 @@ export interface VerseLinkProps {
  */
 export function VerseLink({ reference, onClick }: VerseLinkProps) {
   return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation() // Prevent parent click handlers (e.g., question highlight)
-        onClick()
-      }}
-      className="text-accent underline underline-offset-2 hover:text-accent/80 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-1 rounded px-0.5 -mx-0.5 transition-colors"
-      aria-label={`Open verse ${reference.raw}`}
-    >
-      {reference.raw}
-    </button>
+    <>
+      {" "}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation() // Prevent parent click handlers (e.g., question highlight)
+          onClick()
+        }}
+        className="text-accent underline underline-offset-2 hover:text-accent/80 focus:outline-none focus:ring-2 focus:ring-accent/50 focus:ring-offset-1 rounded px-0.5 transition-colors"
+        aria-label={`Open verse ${reference.raw}`}
+      >
+        {reference.raw}
+      </button>
+      {" "}
+    </>
   )
 }

--- a/mfers-app/src/components/ui/tabs.tsx
+++ b/mfers-app/src/components/ui/tabs.tsx
@@ -137,7 +137,9 @@ const TabsTrigger = forwardRef<HTMLButtonElement, TabsTriggerProps>(
           "focus-visible:ring-accent focus-visible:ring-offset-2",
           "disabled:pointer-events-none disabled:opacity-50",
           "min-h-[36px] min-w-[60px]", // Touch-friendly
-          isActive && "bg-background text-foreground shadow-sm",
+          isActive
+            ? "bg-accent text-accent-foreground shadow-md border-2 border-accent-foreground/20"
+            : "text-muted-foreground hover:text-foreground hover:bg-muted/50",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
Fixes two visual bugs:

### 1. Translation Tab Selection (#25 Epic)
- Selected tab now uses accent background color with subtle border
- Much clearer visual distinction between active and inactive tabs
- Better contrast and visibility

### 2. Verse Link Spacing
- Fixed issue where text ran together with verse links (e.g., 'inJohn 3:16' instead of 'in John 3:16')
- Added proper spacing before and after verse link buttons
- Applies to both reading content and question text

## Testing
- [x] TypeScript compiles without errors
- [x] ESLint passes
- [ ] Visual verification needed after deploy

## Files Changed
- `mfers-app/src/components/ui/tabs.tsx` - Enhanced active tab styling
- `mfers-app/src/components/reading/VerseLink.tsx` - Added spacing wrapper

Related to Epic #25