### PR TITLE
feat: Add week selector dropdown for quick navigation

### DIFF
--- a/mfers-app/src/components/ui/index.ts
+++ b/mfers-app/src/components/ui/index.ts
@@ -42,3 +42,9 @@ export {
   VerseSkeleton,
   type SkeletonProps
 } from "./skeleton"
+
+export {
+  Sheet,
+  SheetContent,
+  type SheetProps
+} from "./sheet"

--- a/mfers-app/src/components/ui/sheet.tsx
+++ b/mfers-app/src/components/ui/sheet.tsx
@@ -1,0 +1,133 @@
+import { X } from "lucide-react";
+import {
+  forwardRef,
+  useEffect,
+  useRef,
+  type HTMLAttributes,
+  type ReactNode,
+} from "react";
+import { cn } from "../../lib/utils";
+import { Button } from "./button";
+
+/**
+ * Sheet/Bottom sheet component props.
+ */
+export interface SheetProps {
+  /** Whether the sheet is open */
+  isOpen: boolean;
+  /** Callback when sheet should close */
+  onClose: () => void;
+  /** Sheet content */
+  children: ReactNode;
+  /** Additional class names */
+  className?: string;
+  /** Title for the sheet header */
+  title?: string;
+}
+
+/**
+ * Bottom sheet component for mobile-friendly selection menus.
+ * Slides up from the bottom with backdrop.
+ *
+ * @example
+ * <Sheet isOpen={isOpen} onClose={() => setIsOpen(false)} title="Select Week">
+ *   <SheetContent>...</SheetContent>
+ * </Sheet>
+ */
+export function Sheet({
+  isOpen,
+  onClose,
+  children,
+  className,
+  title,
+}: SheetProps) {
+  const sheetRef = useRef<HTMLDivElement>(null);
+
+  // Handle escape key
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleEscape);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleEscape);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  // Handle click outside
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-50 flex items-end justify-center",
+        "bg-black/50 backdrop-blur-sm",
+        "animate-in fade-in duration-200"
+      )}
+      onClick={handleBackdropClick}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "sheet-title" : undefined}
+    >
+      <div
+        ref={sheetRef}
+        className={cn(
+          "w-full max-h-[70vh] rounded-t-xl bg-surface",
+          "overflow-hidden shadow-xl",
+          "animate-in slide-in-from-bottom duration-300",
+          className
+        )}
+      >
+        {/* Drag handle indicator */}
+        <div className="flex justify-center pt-3 pb-2">
+          <div className="w-10 h-1 rounded-full bg-muted-foreground/30" />
+        </div>
+
+        {/* Header with title and close */}
+        {title && (
+          <div className="flex items-center justify-between px-4 pb-3 border-b border-border">
+            <h2 id="sheet-title" className="text-lg font-semibold">
+              {title}
+            </h2>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              aria-label="Close"
+              className="min-w-[44px] min-h-[44px]"
+            >
+              <X className="h-5 w-5" aria-hidden="true" />
+            </Button>
+          </div>
+        )}
+
+        {/* Content */}
+        <div className="overflow-y-auto max-h-[calc(70vh-80px)]">
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Sheet content wrapper for consistent padding.
+ */
+const SheetContent = forwardRef<HTMLDivElement, HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-4", className)} {...props} />
+  )
+);
+SheetContent.displayName = "SheetContent";
+
+export { SheetContent };

--- a/mfers-app/src/components/week/WeekNavigation.tsx
+++ b/mfers-app/src/components/week/WeekNavigation.tsx
@@ -17,6 +17,8 @@ export interface WeekNavigationProps {
   onNext: () => void;
   /** Whether this is the current week */
   isCurrentWeek?: boolean;
+  /** Callback when title is clicked to open week selector */
+  onTitleClick?: () => void;
 }
 
 /**
@@ -40,6 +42,7 @@ export function WeekNavigation({
   onPrevious,
   onNext,
   isCurrentWeek = false,
+  onTitleClick,
 }: WeekNavigationProps) {
   return (
     <header className="sticky top-0 z-10 h-14 flex items-center justify-between px-4 bg-surface border-b border-border">
@@ -54,16 +57,31 @@ export function WeekNavigation({
         <ChevronLeft className="h-5 w-5" aria-hidden="true" />
       </Button>
 
-      <div className="flex flex-col items-center">
-        <h1 className="text-lg font-semibold">{weekTitle}</h1>
-        {isCurrentWeek && (
-          <span
-            className="w-2 h-2 rounded-full bg-accent mt-1"
-            role="img"
-            aria-label="This is the current week"
-          />
+      {/* Tappable title to open week selector */}
+      <button
+        type="button"
+        onClick={onTitleClick}
+        className={cn(
+          "flex flex-col items-center gap-0.5 px-3 py-1 rounded-lg",
+          "transition-colors duration-150",
+          "hover:bg-muted/50 active:bg-muted",
+          "focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2",
+          "min-h-[44px] justify-center"
         )}
-      </div>
+        aria-label="Open week selector"
+        aria-haspopup="dialog"
+      >
+        <div className="flex items-center gap-1">
+          <h1 className="text-lg font-semibold">{weekTitle}</h1>
+          <ChevronDown
+            className="h-4 w-4 text-muted-foreground"
+            aria-hidden="true"
+          />
+        </div>
+        {isCurrentWeek && (
+          <span className="text-xs text-accent font-medium">This Week</span>
+        )}
+      </button>
 
       <Button
         variant="ghost"

--- a/mfers-app/src/components/week/WeekSelector.tsx
+++ b/mfers-app/src/components/week/WeekSelector.tsx
@@ -1,0 +1,176 @@
+import { Calendar, Check } from "lucide-react";
+import { cn } from "../../lib/utils";
+import { Sheet } from "../ui/sheet";
+import type { Week } from "../../types/week";
+
+/**
+ * Format a date for display in the week list.
+ */
+function formatWeekListDate(dateString: string): string {
+  const date = new Date(dateString);
+  return date.toLocaleDateString("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Check if a date is in the current week.
+ */
+function isCurrentWeek(dateString: string): boolean {
+  const weekDate = new Date(dateString);
+  const today = new Date();
+  
+  // Get start of the week (Sunday) for both dates
+  const getWeekStart = (d: Date) => {
+    const start = new Date(d);
+    start.setDate(d.getDate() - d.getDay());
+    start.setHours(0, 0, 0, 0);
+    return start;
+  };
+  
+  return getWeekStart(weekDate).getTime() === getWeekStart(today).getTime();
+}
+
+/**
+ * Check if a date is in the past.
+ */
+function isPastWeek(dateString: string): boolean {
+  const weekDate = new Date(dateString);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  weekDate.setHours(0, 0, 0, 0);
+  return weekDate < today && !isCurrentWeek(dateString);
+}
+
+/**
+ * Props for WeekSelector component.
+ */
+export interface WeekSelectorProps {
+  /** Whether the selector is open */
+  isOpen: boolean;
+  /** Callback when selector should close */
+  onClose: () => void;
+  /** List of all weeks */
+  weeks: Week[];
+  /** Currently selected week ID */
+  selectedWeekId: string;
+  /** Current week ID (today's week) */
+  currentWeekId: string;
+  /** Callback when a week is selected */
+  onSelectWeek: (weekId: string) => void;
+}
+
+/**
+ * Week selector bottom sheet with list of all study weeks.
+ * Shows current week indicator and allows quick navigation.
+ *
+ * @example
+ * <WeekSelector
+ *   isOpen={showSelector}
+ *   onClose={() => setShowSelector(false)}
+ *   weeks={sortedWeeks}
+ *   selectedWeekId={currentWeek.weekId}
+ *   currentWeekId={todayWeekId}
+ *   onSelectWeek={(id) => navigateToWeek(id)}
+ * />
+ */
+export function WeekSelector({
+  isOpen,
+  onClose,
+  weeks,
+  selectedWeekId,
+  currentWeekId,
+  onSelectWeek,
+}: WeekSelectorProps) {
+  const handleSelect = (weekId: string) => {
+    onSelectWeek(weekId);
+    onClose();
+  };
+
+  return (
+    <Sheet isOpen={isOpen} onClose={onClose} title="Select Study Week">
+      <div className="py-2">
+        {weeks.length === 0 ? (
+          <div className="px-4 py-8 text-center text-muted-foreground">
+            <Calendar className="h-12 w-12 mx-auto mb-3 opacity-50" />
+            <p>No study weeks available</p>
+          </div>
+        ) : (
+          <ul role="listbox" aria-label="Study weeks">
+            {weeks.map((week) => {
+              const isSelected = week.weekId === selectedWeekId;
+              const isCurrent = week.weekId === currentWeekId;
+              const isPast = isPastWeek(week.weekDate);
+
+              return (
+                <li key={week.weekId}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={isSelected}
+                    onClick={() => handleSelect(week.weekId)}
+                    className={cn(
+                      "w-full flex items-center justify-between px-4 py-3",
+                      "min-h-[56px] text-left",
+                      "transition-colors duration-150",
+                      "hover:bg-muted/50 active:bg-muted",
+                      "focus:outline-none focus:bg-muted",
+                      isSelected && "bg-accent/10",
+                      isPast && "opacity-60"
+                    )}
+                  >
+                    <div className="flex items-center gap-3">
+                      {/* Selection indicator */}
+                      <div
+                        className={cn(
+                          "w-5 h-5 rounded-full flex items-center justify-center",
+                          "border-2 transition-colors",
+                          isSelected
+                            ? "border-accent bg-accent"
+                            : "border-muted-foreground/30"
+                        )}
+                      >
+                        {isSelected && (
+                          <Check className="h-3 w-3 text-accent-foreground" />
+                        )}
+                      </div>
+
+                      {/* Week info */}
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={cn(
+                              "font-medium",
+                              isSelected && "text-accent"
+                            )}
+                          >
+                            {formatWeekListDate(week.weekDate)}
+                          </span>
+                          {isCurrent && (
+                            <span className="text-xs bg-accent/20 text-accent px-2 py-0.5 rounded-full font-medium">
+                              This Week
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground mt-0.5 truncate max-w-[250px]">
+                          {week.readingAssignment}
+                        </p>
+                      </div>
+                    </div>
+
+                    {/* Calendar icon for current */}
+                    {isCurrent && (
+                      <Calendar className="h-4 w-4 text-accent flex-shrink-0" />
+                    )}
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </Sheet>
+  );
+}

--- a/mfers-app/src/components/week/WeekViewer.tsx
+++ b/mfers-app/src/components/week/WeekViewer.tsx
@@ -7,6 +7,7 @@ import { QuestionList } from "../questions/QuestionList";
 import { ReadingContent } from "../reading/ReadingContent";
 import { Skeleton } from "../ui/skeleton";
 import { WeekNavigation } from "./WeekNavigation";
+import { WeekSelector } from "./WeekSelector";
 
 /**
  * Format a date string for display in the week header.
@@ -98,6 +99,9 @@ export function WeekViewer({ onVerseClick }: WeekViewerProps) {
   const hasNext = safeWeekIndex < sortedWeeks.length - 1;
   const isCurrentWeek = week?.weekId === currentWeekId;
 
+  // Week selector state
+  const [showWeekSelector, setShowWeekSelector] = useState(false);
+
   // Highlights from store - must be called before any returns
   const { getHighlights, toggleHighlight } = useHighlightsStore();
   const highlights = week ? getHighlights(week.weekId) : new Set<string>();
@@ -114,6 +118,17 @@ export function WeekViewer({ onVerseClick }: WeekViewerProps) {
       setWeekIndex((prev) => prev + 1);
     }
   }, [hasNext]);
+
+  // Week selector handler
+  const handleSelectWeek = useCallback(
+    (weekId: string) => {
+      const idx = sortedWeeks.findIndex((w) => w.weekId === weekId);
+      if (idx !== -1) {
+        setWeekIndex(idx);
+      }
+    },
+    [sortedWeeks]
+  );
 
   // Verse click handler
   const handleVerseClick = useCallback(
@@ -183,6 +198,7 @@ export function WeekViewer({ onVerseClick }: WeekViewerProps) {
         onPrevious={handlePrevious}
         onNext={handleNext}
         isCurrentWeek={isCurrentWeek}
+        onTitleClick={() => setShowWeekSelector(true)}
       />
 
       <main>
@@ -200,6 +216,16 @@ export function WeekViewer({ onVerseClick }: WeekViewerProps) {
           onVerseClick={handleVerseClick}
         />
       </main>
+
+      {/* Week Selector Bottom Sheet */}
+      <WeekSelector
+        isOpen={showWeekSelector}
+        onClose={() => setShowWeekSelector(false)}
+        weeks={sortedWeeks}
+        selectedWeekId={week.weekId}
+        currentWeekId={currentWeekId}
+        onSelectWeek={handleSelectWeek}
+      />
     </div>
   );
 }

--- a/mfers-app/src/components/week/index.ts
+++ b/mfers-app/src/components/week/index.ts
@@ -2,4 +2,5 @@
  * Week components barrel export.
  */
 export { WeekNavigation, type WeekNavigationProps } from "./WeekNavigation"
+export { WeekSelector, type WeekSelectorProps } from "./WeekSelector"
 export { WeekViewer, type WeekViewerProps } from "./WeekViewer"


### PR DESCRIPTION
## Summary
Implements a week selector dropdown/bottom sheet that allows users to quickly jump to any study week.

### Features
- **Tappable week title**: Click the week title in the header to open the selector
- **Bottom sheet UI**: Mobile-friendly slide-up sheet with drag handle indicator
- **Week list**: Shows all study weeks with:
  - Date formatted as 'Tue, Dec 23'
  - Reading assignment preview
  - 'This Week' badge for current week
  - Selection checkmark for current view
  - Past weeks slightly dimmed
- **Quick navigation**: Tap any week to immediately navigate to it

### Screenshots
The week selector opens when tapping the header title (now shows a chevron-down icon to indicate it's tappable).

## Technical Details
- New `Sheet` component (reusable bottom sheet)
- New `WeekSelector` component
- Updated `WeekNavigation` to accept `onTitleClick` prop
- Updated `WeekViewer` to manage selector state

## Testing
- [x] TypeScript compiles
- [x] ESLint passes
- [ ] Manual testing on mobile

Closes #27